### PR TITLE
Cleaned up turret state logic

### DIFF
--- a/Competition/src/main/cpp/ValorAuto.cpp
+++ b/Competition/src/main/cpp/ValorAuto.cpp
@@ -51,14 +51,14 @@ ValorAuto::ValorAuto(Drivetrain *_drivetrain, Shooter *_shooter, Feeder *_feeder
 
     frc2::InstantCommand cmd_shooterPrime = frc2::InstantCommand( [&] {
         shooter->state.flywheelState = Shooter::FlywheelState::FLYWHEEL_PRIME; 
-        shooter->state.turretState = Shooter::TurretState::TURRET_PRIME;
-        shooter->state.hoodState = Shooter::HoodState::HOOD_PRIME;
+        shooter->state.turretState = Shooter::TurretState::TURRET_TRACK;
+        shooter->state.hoodState = Shooter::HoodState::HOOD_TRACK;
     } );
 
     frc2::InstantCommand cmd_shooterDefault = frc2::InstantCommand( [&] {
         shooter->state.flywheelState = Shooter::FlywheelState::FLYWHEEL_DEFAULT; 
-        shooter->state.turretState = Shooter::TurretState::TURRET_DEFAULT;
-        shooter->state.hoodState = Shooter::HoodState::HOOD_DISABLE;
+        shooter->state.turretState = Shooter::TurretState::TURRET_DISABLE;
+        shooter->state.hoodState = Shooter::HoodState::HOOD_DOWN;
     } );
 
     frc2::InstantCommand cmd_intakeAuto = frc2::InstantCommand( [&] { feeder->state.feederState = Feeder::FeederState::FEEDER_INTAKE; } );
@@ -69,7 +69,7 @@ ValorAuto::ValorAuto(Drivetrain *_drivetrain, Shooter *_shooter, Feeder *_feeder
         feeder->state.feederState = Feeder::FeederState::FEEDER_DISABLE;
         shooter->state.flywheelState = Shooter::FlywheelState::FLYWHEEL_DISABLE; 
         shooter->state.turretState = Shooter::TurretState::TURRET_DISABLE;
-        shooter->state.hoodState = Shooter::HoodState::HOOD_DISABLE;
+        shooter->state.hoodState = Shooter::HoodState::HOOD_DOWN;
     });
 
     // frc2::InstantCommand cmd_set_gyroOffset = frc2::InstantCommand( [&] {

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -124,9 +124,9 @@ namespace ShooterConstants{
     constexpr static double limelightHeight = .6075;
     
 
-    constexpr static double flywheelKP = 0.1;
+    constexpr static double flywheelKP = 0.35;
     constexpr static double flywheelKI = 0;
-    constexpr static double flywheelKD = 5;
+    constexpr static double flywheelKD = 7.5;
     constexpr static double flywheelKIZ = 0;
     constexpr static double flywheelKFF = 0.05;
     constexpr static double MaxRPM = 6380;
@@ -136,19 +136,19 @@ namespace ShooterConstants{
     constexpr static double flywheelMaxAccel = flywheelCruiseVelo * 1;
     constexpr static double flywheelAllowedError = 0;
 
-    constexpr static double flywheelPrimedValue = .46;
-    constexpr static double flywheelDefaultValue = 0.3;
+    constexpr static double flywheelPrimedValue = 0.4;
+    constexpr static double flywheelDefaultValue = 0.37;
 
-    constexpr static double turretKP = 0;
+    constexpr static double turretKP = 1e-9;
     constexpr static double turretKI = 0;
-    constexpr static double turretKD = 0;
+    constexpr static double turretKD = 1;
     constexpr static double turretKIZ = 0;
-    constexpr static double turretKFF = 0.00023;
+    constexpr static double turretKFF = 0.00005;
 
-    constexpr static double turretMaxV = 2000;
+    constexpr static double turretMaxV = 10000;
     constexpr static double turretMinV = 0;
-    constexpr static double turretMaxAccel = 1500;
-    constexpr static double turretAllowedError = 0;
+    constexpr static double turretMaxAccel = turretMaxV * 10;
+    constexpr static double turretAllowedError = 3;
 
     constexpr static double hoodKP = 5e-5;
     constexpr static double hoodKI = 0;
@@ -206,11 +206,11 @@ namespace FeederConstants{
     constexpr static double DEFAULT_INTAKE_SPEED_REVERSE = -0.9;
 
     constexpr static double DEFAULT_FEEDER_SPEED_FORWARD_DEFAULT = 0.5;
-    constexpr static double DEFAULT_FEEDER_SPEED_FORWARD_SHOOT = 1.0;
+    constexpr static double DEFAULT_FEEDER_SPEED_FORWARD_SHOOT = 0.7;
     constexpr static double DEFAULT_FEEDER_SPEED_REVERSE = -1.0;
 
     constexpr static int CACHE_SIZE = 25;
-    constexpr static double JAM_CURRENT = 25;
+    constexpr static double JAM_CURRENT = 30;
 }
 
 namespace MathConstants{

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -161,11 +161,11 @@ namespace ShooterConstants{
     constexpr static double hoodMaxAccel = hoodMaxV * 1;
     constexpr static double hoodAllowedError = 0;
 
-    constexpr static int hoodTop = 2;
+    constexpr static int hoodTop = 5;
     constexpr static int hoodBottom = 0; //make sure this is always 0, need to initialize hood all the way down
 
-    constexpr static double hoodLimitTop = hoodTop + 1;
-    constexpr static double hoodLimitBottom = hoodBottom;
+    constexpr static double hoodLimitTop = 13;
+    constexpr static double hoodLimitBottom = 0;
 
     constexpr static double hoodGearRatio = 1 / 454.17; 
 
@@ -175,8 +175,6 @@ namespace ShooterConstants{
     constexpr static double TURRET_SPEED_MULTIPLIER = .5;
     constexpr static double pSoftDeadband = 0.1;
 
-    constexpr static double homePosition = 90;
-
     constexpr static double falconMaxRPM = 6380;
     constexpr static double falconGearRatio = 1;
 
@@ -184,7 +182,9 @@ namespace ShooterConstants{
 
     // Encoder ticks off of center
     // 192 (gear ration) * angle ratio (ex. 1/2 for 180 deg)
-    constexpr static double turretLimitLeft = 40; //40
+
+    constexpr static double homePosition = 90;
+    constexpr static double turretLimitLeft = 180;
     constexpr static double turretLimitRight = 0;
 
     constexpr static double hubX = 0;

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -113,10 +113,10 @@ namespace ShooterConstants{
     constexpr static int CAN_ID_TURRET = 12;
     constexpr static int CAN_ID_HOOD = 15;    
 
-    constexpr static double aPower = .0357;
-    constexpr static double aHood = 8.57;
+    constexpr static double aPower = 0.0747;
+    constexpr static double aHood = 9.15;
     constexpr static double bPower = .394;
-    constexpr static double bHood = -15.1;
+    constexpr static double bHood = -1.13;
     
     constexpr static double limelightTurnKP = (.3 / 25.445) * 1.25;
     constexpr static double limelightAngle = 50;

--- a/Competition/src/main/include/subsystems/Shooter.h
+++ b/Competition/src/main/include/subsystems/Shooter.h
@@ -50,26 +50,26 @@ public:
 
      double getTargetTics(double, double, double, double, double, double, double);
      double convertTargetTics(double, double);
-     void resetHood();
 
     enum TurretState{
-         TURRET_DISABLE,
-         TURRET_MANUAL,
-         TURRET_HOME,
-         TURRET_DEFAULT,
-         TURRET_PRIME
+         TURRET_DISABLE, // Not moving
+         TURRET_MANUAL, // Manual control from operator
+         TURRET_HOME, // In process of moving to home
+         TURRET_TRACK, // Tracking via limelight
+         TURRET_AUTO // Using odometry to hub
     };
 
     enum HoodState{
-         HOOD_DISABLE,
-         HOOD_PRIME,
-         HOOD_RESET
+         HOOD_DOWN, // Down position
+         HOOD_UP, // Up position
+         HOOD_TRACK // Tracking using limelight
      };
 
      enum FlywheelState{
-          FLYWHEEL_DISABLE,
-          FLYWHEEL_DEFAULT,
-          FLYWHEEL_PRIME
+          FLYWHEEL_DISABLE, // Not moving
+          FLYWHEEL_DEFAULT, // Low speed
+          FLYWHEEL_PRIME, // Higher speed
+          FLYWHEEL_TRACK // Dynamic calculations
      };
 
     struct x
@@ -93,11 +93,11 @@ public:
           double flywheelTarget; //vel
           int hoodTarget; //pos
 
-          double flywheelLow;
-          double flywheelHigh;
+          double flywheelLow; // Low setpoint
+          double flywheelHigh; // High setpoint
 
-          double hoodLow;
-          double hoodHigh;
+          double hoodLow; // Low position
+          double hoodHigh; // High position
 
           bool trackCorner;
 


### PR DESCRIPTION
Read through the turret logic and realized that we had deviated from the expected behavior of the Valor Subsystem state machine.

Brought the code back to the standards of writing states in input, and reading state to assign outputs in assign outputs. Notable exceptions occur in analyze dashboard to allow some customization in auto.

Biggest item: Renamed the states to make more sense. "Primed" didn't make sense - instead, use "up"/"down"/"track"