### PR TITLE
shooter resetState to robotInit

### DIFF
--- a/Competition/src/main/cpp/Robot.cpp
+++ b/Competition/src/main/cpp/Robot.cpp
@@ -14,6 +14,7 @@ void Robot::RobotInit() {
     //m_container.m_drivetrain.resetState();
     // m_container.m_drivetrain.setKF();
     // m_container.m_drivetrain.pullSwerveModuleZeroReference();
+    m_container.m_shooter.resetState();
 }
 
 /**


### PR DESCRIPTION
limelight is turned off at robot init by running resetState of shooter