### PR TITLE
Rotate shooter to right home if lift exceeds a value greater than a threshold

### DIFF
--- a/Competition/src/main/cpp/subsystems/Shooter.cpp
+++ b/Competition/src/main/cpp/subsystems/Shooter.cpp
@@ -27,6 +27,7 @@ void Shooter::setDrivetrain(Drivetrain *dt){
 void Shooter::init()
 {
     limeTable = nt::NetworkTableInstance::GetDefault().GetTable("limelight");
+    liftTable = nt::NetworkTableInstance::GetDefault().GetTable("Lift");
     initTable("Shooter");
     
     table->PutBoolean("Home Turret", false);
@@ -225,6 +226,10 @@ void Shooter::analyzeDashboard()
             state.flywheelState = FlywheelState::FLYWHEEL_TRACK;
         if (state.hoodState == HoodState::HOOD_UP)
             state.hoodState = HoodState::HOOD_TRACK;
+    }
+
+    if (liftTable->GetNumber("Lift Main Encoder Value", 0) > ShooterConstants::turretRotateLiftThreshold) {
+        state.turretState = TurretState::TURRET_HOME_RIGHT;
     }
 
     if (state.turretState == TurretState::TURRET_TRACK && state.lastTurretState != TurretState::TURRET_TRACK){

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -192,8 +192,7 @@ namespace ShooterConstants{
     constexpr static double turretLimitLeft = 180;
     constexpr static double turretLimitRight = 0;
 
-    constexpr static double turretRotateLiftThreshold = (LiftConstants::rotateNoLowerThreshold * 5) / 6;
-
+    constexpr static double turretRotateLiftThreshold = 64500;
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -192,6 +192,8 @@ namespace ShooterConstants{
     constexpr static double turretLimitLeft = 180;
     constexpr static double turretLimitRight = 0;
 
+    constexpr static double turretRotateLiftThreshold = 77500;
+
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -192,7 +192,7 @@ namespace ShooterConstants{
     constexpr static double turretLimitLeft = 180;
     constexpr static double turretLimitRight = 0;
 
-    constexpr static double turretRotateLiftThreshold = 64500;
+    constexpr static double turretRotateLiftThreshold = 35000; // lowered from 64500
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -192,7 +192,7 @@ namespace ShooterConstants{
     constexpr static double turretLimitLeft = 180;
     constexpr static double turretLimitRight = 0;
 
-    constexpr static double turretRotateLiftThreshold = 77500;
+    constexpr static double turretRotateLiftThreshold = (LiftConstants::rotateNoLowerThreshold * 5) / 6;
 
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;

--- a/Competition/src/main/include/subsystems/Shooter.h
+++ b/Competition/src/main/include/subsystems/Shooter.h
@@ -130,6 +130,7 @@ private:
 
      frc::XboxController *operatorController;
      std::shared_ptr<nt::NetworkTable> limeTable;
+     std::shared_ptr<nt::NetworkTable> liftTable;
 
      Drivetrain *odom;
 };


### PR DESCRIPTION
shooter analyze dashboard: main lift encoder exceeds threshold -> turretState = right_home