### PR TITLE
feat: Add new ValorSensor construct

### DIFF
--- a/Competition/src/main/cpp/ValorAuto.cpp
+++ b/Competition/src/main/cpp/ValorAuto.cpp
@@ -139,7 +139,7 @@ ValorAuto::ValorAuto(Drivetrain *_drivetrain, Shooter *_shooter, Feeder *_feeder
     frc2::InstantCommand cmd_intakeOne = frc2::InstantCommand( [&] { feeder->state.feederState = Feeder::FeederState::FEEDER_REGULAR_INTAKE; } );
     frc2::InstantCommand cmd_intakeDisable = frc2::InstantCommand( [&] { feeder->state.feederState = Feeder::FeederState::FEEDER_DISABLE; } );
     frc2::InstantCommand cmd_intakeAuto = frc2::InstantCommand( [&] { feeder->state.feederState = Feeder::FeederState::FEEDER_CURRENT_INTAKE; } );
-    frc2::InstantCommand cmd_intakeClearDeque = frc2::InstantCommand( [&] { feeder->resetDeque();} );    
+    frc2::InstantCommand cmd_intakeClearDeque = frc2::InstantCommand( [&] { feeder->resetIntakeSensor();} );    
     frc2::InstantCommand cmd_intakeShoot = frc2::InstantCommand( [&] { feeder->state.feederState = Feeder::FeederState::FEEDER_SHOOT; } );
     frc2::InstantCommand cmd_intakeReverse = frc2::InstantCommand( [&] { feeder->state.feederState = Feeder::FeederState::FEEDER_REVERSE; } );
 

--- a/Competition/src/main/cpp/sensors/ValorCurrentSensor.cpp
+++ b/Competition/src/main/cpp/sensors/ValorCurrentSensor.cpp
@@ -1,0 +1,42 @@
+#include "sensors/ValorCurrentSensor.h"
+
+#define CACHE_SIZE 20
+#define DEFAULT_SPIKE_VALUE 22
+
+ValorCurrentSensor::ValorCurrentSensor() :
+    spikedSetpoint(DEFAULT_SPIKE_VALUE)
+{
+    reset();
+}
+
+void ValorCurrentSensor::setSpikeSetpoint(double _setpoint)
+{
+    spikedSetpoint = _setpoint;
+}
+
+bool ValorCurrentSensor::spiked() {
+    return currState > spikedSetpoint;
+}
+
+void ValorCurrentSensor::reset() {
+    cache.clear();
+    for (int i = 0; i < CACHE_SIZE; i++) {
+        cache.push_back(0);
+    }
+    prevState = 0;
+    currState = 0;
+}
+
+void ValorCurrentSensor::calculate() {
+    cache.pop_front();
+    cache.push_back(getSensor());
+
+    // Calculate average current over the cache size, or circular buffer window
+    double sum = 0;
+    for (int i = 0; i < CACHE_SIZE; i++) {
+        sum += cache.at(i);
+    }
+
+    currState = sum / CACHE_SIZE;
+    prevState = currState;
+}

--- a/Competition/src/main/cpp/sensors/ValorDebounceSensor.cpp
+++ b/Competition/src/main/cpp/sensors/ValorDebounceSensor.cpp
@@ -1,0 +1,24 @@
+#include "sensors/ValorDebounceSensor.h"
+
+ValorDebounceSensor::ValorDebounceSensor()
+{
+}
+
+void ValorDebounceSensor::reset()
+{
+    prevState = false;
+    currState = false;
+    isSpiked = false;
+}
+
+bool ValorDebounceSensor::spiked()
+{
+    return isSpiked;
+}
+
+void ValorDebounceSensor::calculate()
+{
+    currState = getSensor();
+    isSpiked = currState != prevState;
+    prevState = currState;
+}

--- a/Competition/src/main/include/sensors/ValorCurrentSensor.h
+++ b/Competition/src/main/include/sensors/ValorCurrentSensor.h
@@ -1,0 +1,33 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "sensors/ValorSensor.h"
+#include <deque>
+#include <ctre/Phoenix.h>
+
+#ifndef VALORCURRENTSENSOR_H
+#define VALORCURRENTSENSOR_H
+
+class ValorCurrentSensor : public ValorSensor<double>
+{
+public:
+    ValorCurrentSensor();
+
+    void reset();
+    void calculate();
+
+    bool spiked();
+    void setSpikeSetpoint(double);
+
+private:
+    std::deque<double> cache;
+    double spikedSetpoint;
+};
+
+#endif;

--- a/Competition/src/main/include/sensors/ValorDebounceSensor.h
+++ b/Competition/src/main/include/sensors/ValorDebounceSensor.h
@@ -1,0 +1,30 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include "sensors/ValorSensor.h"
+#include <functional>
+
+#ifndef VALORDEBOUNCESENSOR_H
+#define VALORDEBOUNCESENSOR_H
+
+class ValorDebounceSensor : public ValorSensor<bool>
+{
+public:
+    ValorDebounceSensor();
+    
+    void reset();
+    void calculate();
+
+    bool spiked();
+
+private:
+    bool isSpiked;
+};
+
+#endif;

--- a/Competition/src/main/include/sensors/ValorSensor.h
+++ b/Competition/src/main/include/sensors/ValorSensor.h
@@ -22,7 +22,7 @@ public:
     virtual void calculate() = 0;
 
     void setGetter(std::function<T()> _lambda) { sensorLambda = _lambda; }
-    T getSensor() { return sensorLambda(); }
+    T getSensor() { return sensorLambda ? sensorLambda() : 0; }
 
 protected:
     std::function<T()> sensorLambda;

--- a/Competition/src/main/include/sensors/ValorSensor.h
+++ b/Competition/src/main/include/sensors/ValorSensor.h
@@ -1,0 +1,33 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <functional>
+
+#ifndef VALORSENSOR_H
+#define VALORSENSOR_H
+
+template <class T>
+class ValorSensor
+{
+public:
+    ValorSensor() {}
+    
+    virtual void reset() = 0;
+    virtual void calculate() = 0;
+
+    void setGetter(std::function<T()> _lambda) { sensorLambda = _lambda; }
+    T getSensor() { return sensorLambda(); }
+
+protected:
+    std::function<T()> sensorLambda;
+    T currState;
+    T prevState;
+};
+
+#endif

--- a/Competition/src/main/include/subsystems/Feeder.h
+++ b/Competition/src/main/include/subsystems/Feeder.h
@@ -14,6 +14,9 @@
 #include <ctre/Phoenix.h>
 #include <frc/DigitalInput.h>
 
+#include "sensors/ValorCurrentSensor.h"
+#include "sensors/ValorDebounceSensor.h"
+
 #ifndef FEEDER_H
 #define FEEDER_H
 
@@ -42,32 +45,19 @@ public:
     struct x
     {
 
-        bool bannerTripped;
-        bool previousBanner;
-        bool currentBanner;
-
         bool reversed;
-
-        bool spiked;
         
         double intakeForwardSpeed;
         double intakeReverseSpeed;
-        double spikeCurrent;
 
         double feederForwardSpeedDefault;
         double feederForwardSpeedShoot;
         double feederReverseSpeed;
-        
-        //int current_cache_index;
-        //std::vector<double> current_cache;
-        std::deque<double> current_cache;
-
-        double instCurrent;
 
         FeederState feederState;
     } state;
 
-void resetDeque();
+    void resetIntakeSensor();
 
 private:
     ValorGamepad *driverController;
@@ -76,11 +66,10 @@ private:
     WPI_TalonFX motor_intake;
     WPI_TalonFX motor_stage;
 
-    frc::DigitalInput banner;
+    ValorCurrentSensor currentSensor;
+    ValorDebounceSensor debounceSensor;
 
-    void calcCurrent();
-    
-    
+    frc::DigitalInput banner;
 
 };
 


### PR DESCRIPTION
Allow sensors to be their own object, which simplifies the logic in the subsystems.

This also allows us to re-use common sensor types year over year.
For example the current sensing circular buffer on our intake is a good sensor to use in the future, therefore create a ValorCurrentSensor that can be used by multiple subsystems