### PR TITLE
feat: Added ValorGamepad class

### DIFF
--- a/Competition/src/main/cpp/ValorGamepad.cpp
+++ b/Competition/src/main/cpp/ValorGamepad.cpp
@@ -1,0 +1,111 @@
+#include "ValorGamepad.h"
+
+#include <math.h>
+
+#define DPAD_UP 0
+#define DPAD_DOWN 180
+#define DPAD_RIGHT 90
+#define DPAD_LEFT 270
+
+#define DEADBAND_X 0.05f
+#define DEADBAND_Y 0.1f
+#define DEADBAND_TRIGGER 0.05f
+
+ValorGamepad::ValorGamepad(int id) :
+    frc::XboxController(id),
+    deadbandX(DEADBAND_X),
+    deadbandY(DEADBAND_Y)
+{
+}
+
+void ValorGamepad::setDeadbandX(double deadband)
+{
+    deadbandX = deadband;
+}
+
+void ValorGamepad::setDeadbandY(double deadband)
+{
+    deadbandY = deadband;
+}
+
+double ValorGamepad::deadband(double input, double deadband, int polynomial)
+{
+    return std::fabs(input) > deadband ? std::pow(input, polynomial) : 0;
+}
+
+double ValorGamepad::leftStickX(int polynomial)
+{
+    return -deadband(GetLeftX(), deadbandX, polynomial);
+}
+
+bool ValorGamepad::leftStickXActive(int polynomial)
+{
+    return leftStickX(polynomial) != 0;
+}
+
+double ValorGamepad::leftStickY(int polynomial)
+{
+    return -deadband(GetLeftY(), deadbandY, polynomial);
+}
+
+bool ValorGamepad::leftStickYActive(int polynomial)
+{
+    return leftStickY(polynomial) != 0;
+}
+
+double ValorGamepad::rightStickX(int polynomial)
+{
+    return -deadband(GetRightX(), deadbandX, polynomial);
+}
+
+bool ValorGamepad::rightStickXActive(int polynomial)
+{
+    return rightStickX(polynomial) != 0;
+}
+
+double ValorGamepad::rightStickY(int polynomial)
+{
+    return -deadband(GetRightY(), deadbandY, polynomial);
+}
+
+bool ValorGamepad::rightStickYActive(int polynomial)
+{
+    return rightStickY(polynomial) != 0;
+}
+
+double ValorGamepad::leftTrigger()
+{
+    return GetLeftTriggerAxis() > DEADBAND_TRIGGER ? GetLeftTriggerAxis() : 0;
+}
+
+bool ValorGamepad::leftTriggerActive()
+{
+    return leftTrigger() != 0;
+}
+
+double ValorGamepad::rightTrigger()
+{
+    return GetRightTriggerAxis() > DEADBAND_TRIGGER ? GetRightTriggerAxis() : 0;
+}
+
+bool ValorGamepad::rightTriggerActive()
+{
+    return rightTrigger() != 0;
+}
+
+bool ValorGamepad::DPadUp()
+{
+    return GetPOV() == DPAD_UP;
+}
+bool ValorGamepad::DPadDown()
+{
+    return GetPOV() == DPAD_DOWN;
+}
+bool ValorGamepad::DPadLeft()
+{
+    return GetPOV() == DPAD_LEFT;
+}
+bool ValorGamepad::DPadRight()
+{
+    return GetPOV() == DPAD_RIGHT;
+}

--- a/Competition/src/main/cpp/subsystems/Feeder.cpp
+++ b/Competition/src/main/cpp/subsystems/Feeder.cpp
@@ -56,7 +56,7 @@ void Feeder::init()
     
 }
 
-void Feeder::setControllers(frc::XboxController *controllerO, frc::XboxController *controllerD)
+void Feeder::setControllers(ValorGamepad *controllerO, ValorGamepad *controllerD)
 {
     driverController = controllerD;
     operatorController = controllerO;
@@ -68,34 +68,18 @@ void Feeder::assessInputs()
     {
         return;
     }
-
-    // driver inputs
-  
-    state.driver_leftBumperPressed = driverController->GetLeftBumper();
-    state.driver_rightBumperPressed = driverController->GetRightBumper();
-
-    state.driver_rightTriggerPressed = driverController->GetRightTriggerAxis() > OIConstants::kDeadBandTrigger;
-    state.driver_leftTriggerPressed = driverController->GetLeftTriggerAxis() > OIConstants::kDeadBandTrigger;
-
-
-    // operator inputs
-
-    state.operator_leftBumperPressed = operatorController->GetLeftBumper();
         
-    if (state.driver_rightTriggerPressed || state.operator_leftBumperPressed) {
+    if (driverController->rightTrigger() || operatorController->GetLeftBumper()) {
         state.feederState = FeederState::FEEDER_SHOOT; //intake and feeder run
         state.spiked = false;
     }
-    else if (state.driver_leftBumperPressed) {
+    else if (driverController->GetLeftBumper()) {
         state.feederState = FeederState::FEEDER_REVERSE;
         state.spiked = false;
     }
-    else if (state.driver_rightBumperPressed) {
+    else if (driverController->GetRightBumper()) {
         state.feederState = FeederState::FEEDER_REGULAR_INTAKE; //standard intake
     }
-    // else if (state.driver_leftTriggerPressed) {
-    //     state.feederState = FeederState::FEEDER_CURRENT_INTAKE; //includes current/banner sensing
-    // }
     else {
         state.feederState = FeederState::FEEDER_DISABLE;
     }

--- a/Competition/src/main/cpp/subsystems/Lift.cpp
+++ b/Competition/src/main/cpp/subsystems/Lift.cpp
@@ -74,7 +74,7 @@ void Lift::init()
     setupCommands();
 }
 
-void Lift::setController(frc::XboxController *controller)
+void Lift::setController(ValorGamepad *controller)
 {
     operatorController = controller;
 }
@@ -185,28 +185,18 @@ void Lift::assessInputs()
         return;
     }
 
-    state.rightStickY = -1 * operatorController->GetRightY();
-
-    state.dPadLeftPressed = operatorController->GetPOV() == OIConstants::dpadLeft;
-    state.dPadRightPressed = operatorController->GetPOV() == OIConstants::dpadRight;
-    state.dPadDownPressed = operatorController->GetPOV() == OIConstants::dpadDown;
-    state.dPadUpPressed = operatorController->GetPOV() == OIConstants::dpadUp;
-
-    state.leftTriggerPressed = operatorController->GetLeftTriggerAxis() > LiftConstants::kDeadBandTrigger;
-    state.rightTriggerPressed = operatorController->GetRightTriggerAxis() > LiftConstants::kDeadBandTrigger;
-
-    if((std::abs(state.rightStickY) > OIConstants::kDeadbandY) && liftSequenceUp.IsScheduled()){
+    if(operatorController->rightStickYActive() && liftSequenceUp.IsScheduled()){
         liftSequenceUp.Cancel();
     }
-    if((std::abs(state.rightStickY) > OIConstants::kDeadbandY) && liftSequenceDown.IsScheduled()){
+    if(operatorController->rightStickYActive() && liftSequenceDown.IsScheduled()){
         liftSequenceDown.Cancel();
     }
 
-    if (state.dPadLeftPressed && leadMainMotor.GetSelectedSensorPosition() > LiftConstants::rotateNoLowerThreshold)
+    if (operatorController->DPadLeft() && leadMainMotor.GetSelectedSensorPosition() > LiftConstants::rotateNoLowerThreshold)
     {
         state.liftstateRotate = LiftRotateState::LIFT_ROTATE_EXTEND;
     }
-    else if (state.dPadRightPressed && leadMainMotor.GetSelectedSensorPosition() > LiftConstants::rotateNoLowerThreshold)
+    else if (operatorController->DPadRight() && leadMainMotor.GetSelectedSensorPosition() > LiftConstants::rotateNoLowerThreshold)
     {
         state.liftstateRotate = LiftRotateState::LIFT_ROTATE_RETRACT;
     }
@@ -215,11 +205,11 @@ void Lift::assessInputs()
         state.liftstateRotate = LiftRotateState::LIFT_ROTATE_DISABLED;
     }
 
-    if (std::abs(state.rightStickY) > OIConstants::kDeadbandY)
+    if (operatorController->rightStickYActive())
     {
         state.liftstateMain = LiftMainState::LIFT_MAIN_ENABLE;
     }
-    else if (state.leftTriggerPressed && state.rightTriggerPressed) {
+    else if (operatorController->leftTriggerActive() && operatorController->rightTriggerActive()) {
         state.liftstateMain = LiftMainState::LIFT_MAIN_FIRSTPOSITION;
     }
     else if(!liftSequenceUp.IsScheduled() && !liftSequenceDown.IsScheduled())
@@ -227,10 +217,10 @@ void Lift::assessInputs()
         state.liftstateMain = LiftMainState::LIFT_MAIN_DISABLED;
     }
 
-    if (state.dPadDownPressed){
+    if (operatorController->DPadDown()){
         liftSequenceDown.Schedule();
     }
-    else if (state.dPadUpPressed) {
+    else if (operatorController->DPadUp()) {
         liftSequenceUp.Schedule();
     }
 
@@ -276,8 +266,9 @@ void Lift::analyzeDashboard()
 void Lift::assignOutputs()
 {
     if (state.liftstateRotate == LiftRotateState::LIFT_ROTATE_DISABLED &&
-    !(state.liftstateMain == LiftMainState::LIFT_MAIN_ENABLE &&
-    state.rightStickY < (-1 * OIConstants::kDeadbandY)))
+        !(state.liftstateMain == LiftMainState::LIFT_MAIN_ENABLE &&
+        operatorController->rightStickYActive() &&
+        operatorController->rightStickY() < 0))
     {
         rotateMotor.Set(0);
     }
@@ -300,11 +291,11 @@ void Lift::assignOutputs()
         leadMainMotor.Set(0);
     }
     else if (state.liftstateMain == LiftMainState::LIFT_MAIN_ENABLE) {
-        if(state.rightStickY > OIConstants::kDeadbandY){
-            leadMainMotor.Set(state.rightStickY * LiftConstants::DEFAULT_MAIN_EXTEND_SPD);
+        if (operatorController->rightStickYActive() && operatorController->rightStickY() > 0) {
+            leadMainMotor.Set(operatorController->rightStickY() * LiftConstants::DEFAULT_MAIN_EXTEND_SPD);
         }
-        else if(state.rightStickY < (-1 * OIConstants::kDeadbandY)){
-            leadMainMotor.Set(state.rightStickY * LiftConstants::DEFAULT_MAIN_RETRACT_SPD);
+        else if (operatorController->rightStickYActive() && operatorController->rightStickY() < 0) {
+            leadMainMotor.Set(operatorController->rightStickY() * LiftConstants::DEFAULT_MAIN_RETRACT_SPD);
             rotateMotor.Set(-0.2);
         }
     }

--- a/Competition/src/main/cpp/subsystems/TurretTracker.cpp
+++ b/Competition/src/main/cpp/subsystems/TurretTracker.cpp
@@ -57,7 +57,7 @@ void TurretTracker::assignOutputs() {
         // 0.75 = limeligh KP
         state.target = (-state.cachedTx * 0.75) + turretPos;
 
-        if(shooter-> state.driverLeftTrigger){
+        if(shooter->driverController->leftTriggerActive()) {
             state.target += 15;
         }
 

--- a/Competition/src/main/include/RobotContainer.h
+++ b/Competition/src/main/include/RobotContainer.h
@@ -17,7 +17,7 @@
 #include "subsystems/Feeder.h"
 #include "subsystems/Lift.h"
 #include "subsystems/TurretTracker.h"
-#include <frc/XboxController.h>
+#include "ValorGamepad.h"
 
 #ifndef ROBOT_CONTAINER_H
 #define ROBOT_CONTAINER_H
@@ -27,8 +27,8 @@ class RobotContainer {
         RobotContainer();
         frc2::Command* GetAutonomousCommand();
 
-        frc::XboxController m_GamepadDriver{OIConstants::GAMEPAD_BASE_LOCATION};
-        frc::XboxController m_GamepadOperator{OIConstants::GAMEPAD_OPERATOR_LOCATION};
+        ValorGamepad m_GamepadDriver{OIConstants::GAMEPAD_BASE_LOCATION};
+        ValorGamepad m_GamepadOperator{OIConstants::GAMEPAD_OPERATOR_LOCATION};
 
         Drivetrain m_drivetrain;
         Shooter m_shooter;

--- a/Competition/src/main/include/ValorGamepad.h
+++ b/Competition/src/main/include/ValorGamepad.h
@@ -1,0 +1,51 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2019 FIRST. All Rights Reserved.                             */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+#pragma once
+
+#include <frc/XboxController.h>
+
+#ifndef VALORGAMEPAD_H
+#define VALORGAMEPAD_H
+
+class ValorGamepad : public frc::XboxController
+{
+public:
+
+    ValorGamepad(int);
+
+    void setDeadbandX(double);
+    void setDeadbandY(double);
+
+    double leftStickX(int polynomial=1);
+    bool leftStickXActive(int polynomial=1);
+    double leftStickY(int polynomial=1);
+    bool leftStickYActive(int polynomial=1);
+
+    double rightStickX(int polynomial=1);
+    bool rightStickXActive(int polynomial=1);
+    double rightStickY(int polynomial=1);
+    bool rightStickYActive(int polynomial=1);
+
+    double rightTrigger();
+    bool rightTriggerActive();
+    double leftTrigger();
+    bool leftTriggerActive();
+
+    bool DPadUp();
+    bool DPadDown();
+    bool DPadLeft();
+    bool DPadRight();
+
+private:
+    double deadband(double, double, int);
+
+    double deadbandX;
+    double deadbandY;
+};
+
+#endif

--- a/Competition/src/main/include/subsystems/Drivetrain.h
+++ b/Competition/src/main/include/subsystems/Drivetrain.h
@@ -10,11 +10,11 @@
 #include "ValorSubsystem.h"
 #include "Constants.h"
 #include "ValorSwerve.h"
+#include "ValorGamepad.h"
 #include <vector>
 
 #include "AHRS.h"
 #include "ctre/phoenix/sensors/WPI_Pigeon2.h"
-#include <frc/XboxController.h>
 #include <frc/kinematics/SwerveDriveKinematics.h>
 #include <frc/kinematics/SwerveDriveOdometry.h>
 #include <frc/DutyCycleEncoder.h>
@@ -45,7 +45,7 @@ public:
     ~Drivetrain();
 
     void init();
-    void setController(frc::XboxController *controller);
+    void setController(ValorGamepad *controller);
 
     void assessInputs();
     void analyzeDashboard();
@@ -55,23 +55,7 @@ public:
 
     struct x
     {
-        double leftStickX;
-        double leftStickY;
-        double rightStickX;
-        double rightStickY;
-
-        bool backButtonPressed;
-        bool startButtonPressed;
         bool stickPressed;
-
-        bool bButtonPressed;
-        bool aButtonPressed;
-        bool xButtonPressed;
-        bool yButtonPressed;
-
-        bool dPadUpPressed;
-        bool dPadDownPressed;
-
         bool tracking;
 
         bool saveToFileDebouncer;
@@ -156,7 +140,7 @@ private:
 
     void configSwerveModule(int);
 
-    frc::XboxController *driverController;
+    ValorGamepad *driverController;
 
     std::vector<ValorSwerve *> swerveModules;
     std::vector<WPI_TalonFX *> azimuthMotors;

--- a/Competition/src/main/include/subsystems/Feeder.h
+++ b/Competition/src/main/include/subsystems/Feeder.h
@@ -9,9 +9,8 @@
 
 #include "ValorSubsystem.h"
 #include "Constants.h"
-#include <deque>
+#include "ValorGamepad.h"
 
-#include <frc/XboxController.h>
 #include <ctre/Phoenix.h>
 #include <frc/DigitalInput.h>
 
@@ -24,7 +23,7 @@ public:
     Feeder();
 
     void init();
-    void setControllers(frc::XboxController *controllerO, frc::XboxController *controllerD);
+    void setControllers(ValorGamepad *controllerO, ValorGamepad *controllerD);
 
     void assessInputs();
     void analyzeDashboard();
@@ -42,16 +41,6 @@ public:
     
     struct x
     {
-        bool driver_rightBumperPressed;
-
-        bool operator_bButtonPressed;
-        bool operator_aButtonPressed;
-
-        bool driver_leftBumperPressed;
-        bool operator_leftBumperPressed;
-
-        bool driver_rightTriggerPressed;
-        bool driver_leftTriggerPressed;
 
         bool bannerTripped;
         bool previousBanner;
@@ -81,8 +70,8 @@ public:
 void resetDeque();
 
 private:
-    frc::XboxController *driverController;
-    frc::XboxController *operatorController;
+    ValorGamepad *driverController;
+    ValorGamepad *operatorController;
 
     WPI_TalonFX motor_intake;
     WPI_TalonFX motor_stage;

--- a/Competition/src/main/include/subsystems/Lift.h
+++ b/Competition/src/main/include/subsystems/Lift.h
@@ -2,7 +2,7 @@
 
 #include "ValorSubsystem.h"
 #include "Constants.h"
-#include <frc/XboxController.h>
+#include "ValorGamepad.h"
 #include <rev/CANSparkMax.h>
 
 #include "ValorSubsystem.h"
@@ -26,7 +26,7 @@ public:
     Lift();
 
     void init();
-    void setController(frc::XboxController *controller);
+    void setController(ValorGamepad *controller);
 
     void assessInputs();
     void analyzeDashboard();
@@ -67,16 +67,6 @@ public:
         LiftRotateState liftstateRotate;
         LiftAutomationState liftStateAutomation;
 
-        bool dPadUpPressed;
-        bool dPadDownPressed;
-        bool dPadLeftPressed;
-        bool dPadRightPressed;
-
-        bool leftTriggerPressed;
-        bool rightTriggerPressed;
-
-        double rightStickY;
-
         double powerRetract;
         double powerExtend;
         double powerMain;
@@ -93,7 +83,7 @@ public:
     void setupCommands();
 
 private:
-    frc::XboxController *operatorController;
+    ValorGamepad *operatorController;
 
     WPI_TalonFX leadMainMotor;
 

--- a/Competition/src/main/include/subsystems/Shooter.h
+++ b/Competition/src/main/include/subsystems/Shooter.h
@@ -11,12 +11,11 @@
 #include "Constants.h"
 #include "ValorSwerve.h"
 #include "Drivetrain.h"
+#include "ValorGamepad.h"
 #include <vector>
 
 #include <rev/CANSparkMax.h>
 #include <rev/CANEncoder.h>
-
-#include <frc/XboxController.h>
 
 #include <frc/shuffleboard/Shuffleboard.h>
 #include <frc/shuffleboard/ShuffleboardLayout.h>
@@ -36,7 +35,7 @@ public:
     Shooter();
 
     void init();
-    void setControllers(frc::XboxController *controllerO, frc::XboxController *controllerD);
+    void setControllers(ValorGamepad *controllerO, ValorGamepad *controllerD);
     void setDrivetrain(Drivetrain * dt);
 
     void assessInputs();
@@ -85,19 +84,6 @@ public:
           TurretState turretState;
           TurretState lastTurretState;
 
-          double leftStickX;
-     
-          bool backButton;
-          bool startButton;
-          bool rightBumper;
-          bool aButton;
-          bool yButton;
-          bool xButtonPressed;
-          bool bButton;
-
-          bool driverLeftTrigger;
-          bool driverDPadUp;
-          bool driverBButton;
           bool driverLastLeftTrigger;
 
           double limelightDistance;
@@ -151,8 +137,8 @@ public:
      rev::SparkMaxRelativeEncoder hoodEncoder = hood.GetEncoder();
      rev::SparkMaxPIDController hoodPidController = hood.GetPIDController();
 
-     frc::XboxController *operatorController;
-     frc::XboxController *driverController;
+     ValorGamepad *operatorController;
+     ValorGamepad *driverController;
 
      std::shared_ptr<nt::NetworkTable> limeTable;
      std::shared_ptr<nt::NetworkTable> liftTable;


### PR DESCRIPTION
Override the frc::XboxController with a new ValorGamepad class
This will inherit all the same methods as XboxController, but also provide additional methods for utilizing a deadband on the X and Y sticks, as well as a deadband on the triggers.

Prevents caching all the values in each subsystem's state struct