### PR TITLE
Fix gamepad bug: Even polynomial on a negative base yields incorrect results

### DIFF
--- a/Competition/src/main/cpp/ValorGamepad.cpp
+++ b/Competition/src/main/cpp/ValorGamepad.cpp
@@ -28,9 +28,16 @@ void ValorGamepad::setDeadbandY(double deadband)
     deadbandY = deadband;
 }
 
+// Get the sign of an input
+template <typename T> int sgn(T val) {
+    return (T(0) < val) - (val < T(0));
+}
+
 double ValorGamepad::deadband(double input, double deadband, int polynomial)
 {
-    return std::fabs(input) > deadband ? std::pow(input, polynomial) : 0;
+    // If input is negative and polynomial is even, output would be positive which is incorrect
+    // Therefore if polynomial is even, multiply pow by the sign of the input
+    return std::fabs(input) > deadband ? ((polynomial % 2 == 0 ? sgn(input) : 1) * std::pow(input, polynomial)) : 0;
 }
 
 double ValorGamepad::leftStickX(int polynomial)


### PR DESCRIPTION
2^1 = 2
2^2 = 4
2^3 = 8

-2^1=-2
-2^2=4
-2^3=-8

The -2^2 case (and any even polynomial with a negative base) would fail for our gamepad. Make sure all negative bases have negative results.