### PR TITLE
Intake retract / extend functionality

### DIFF
--- a/Competition/src/main/cpp/subsystems/Feeder.cpp
+++ b/Competition/src/main/cpp/subsystems/Feeder.cpp
@@ -41,10 +41,7 @@ void Feeder::init()
     motor_stage.SetInverted(true);
     motor_stage.EnableVoltageCompensation(true);
     motor_stage.ConfigVoltageCompSaturation(10);
-
-    
-
-    
+ 
     motor_rotateMain.ConfigForwardSoftLimitThreshold(FeederConstants::rotateForwardLimit);
     motor_rotateMain.ConfigReverseSoftLimitThreshold(FeederConstants::rotateReverseLimit);
 
@@ -52,8 +49,8 @@ void Feeder::init()
     motor_rotateMain.ConfigReverseSoftLimitEnable(true);
 
     motor_rotateMain.SetSelectedSensorPosition(0);
-    motor_rotateMain.SetInverted(false); // needs to be tested
-    motor_rotateFollow.SetInverted(true); // needs to be tested
+    motor_rotateMain.SetInverted(true); // needs to be tested
+    motor_rotateFollow.SetInverted(false); // needs to be tested
     motor_rotateFollow.Follow(motor_rotateMain);   
 
     motor_rotateMain.SetNeutralMode(ctre::phoenix::motorcontrol::Brake);
@@ -110,7 +107,7 @@ void Feeder::assessInputs()
         state.feederState = FeederState::FEEDER_SHOOT; //intake and feeder run
         resetIntakeSensor();
     }
-    else if (driverController->GetBButton()) {
+    else if (driverController->GetXButton()) {
         state.feederState = FeederState::FEEDER_RETRACT; //Set Intake rotate  to upper setpoint
     }
     else if (driverController->GetLeftBumper()) {
@@ -144,6 +141,7 @@ void Feeder::analyzeDashboard()
     table->PutBoolean("Banner: ", debounceSensor.getSensor());
     table->PutNumber("current feeder state", state.feederState);
 
+    table->PutNumber("Intake Encoder Value", motor_rotateMain.GetSelectedSensorPosition());
 }
 
 void Feeder::assignOutputs()

--- a/Competition/src/main/cpp/subsystems/Feeder.cpp
+++ b/Competition/src/main/cpp/subsystems/Feeder.cpp
@@ -52,8 +52,8 @@ void Feeder::init()
     motor_rotateMain.ConfigReverseSoftLimitEnable(true);
 
     motor_rotateMain.SetSelectedSensorPosition(0);
-    motor_rotateMain.SetInverted(false);
-    motor_rotateFollow.SetInverted(true);
+    motor_rotateMain.SetInverted(false); // needs to be tested
+    motor_rotateFollow.SetInverted(true); // needs to be tested
     motor_rotateFollow.Follow(motor_rotateMain);   
 
     motor_rotateMain.SetNeutralMode(ctre::phoenix::motorcontrol::Brake);
@@ -159,7 +159,7 @@ void Feeder::assignOutputs()
         motor_stage.Set(state.feederForwardSpeedShoot);
     }
     else if (state.feederState == FeederState::FEEDER_RETRACT){
-        motor_rotateMain.Set(ControlMode::MotionMagic, FeederConstants::rotateReverseLimit); // set rotation to be up fixme
+        motor_rotateMain.Set(ControlMode::MotionMagic, FeederConstants::rotateReverseLimit); // set rotation to be up
     }
     else if (state.feederState == Feeder::FEEDER_REVERSE) {
         motor_intake.Set(state.intakeReverseSpeed);

--- a/Competition/src/main/cpp/subsystems/Feeder.cpp
+++ b/Competition/src/main/cpp/subsystems/Feeder.cpp
@@ -42,13 +42,34 @@ void Feeder::init()
     motor_stage.EnableVoltageCompensation(true);
     motor_stage.ConfigVoltageCompSaturation(10);
 
-    motor_rotateMain.SetInverted(false);
-    motor_rotateMain.SetNeutralMode(Brake);
+    // motor_rotateMain.SetInverted(false);
+    // motor_rotateMain.SetNeutralMode(Brake);
 
-    motor_rotateFollow.SetInverted(true);
-    motor_rotateFollow.SetNeutralMode(Brake);
-    motor_rotateFollow.Follow(motor_rotateMain);
-    
+    // motor_rotateFollow.SetInverted(true);
+    // motor_rotateFollow.SetNeutralMode(Brake);
+    // motor_rotateFollow.Follow(motor_rotateMain);
+    motor_rotateMain.ConfigForwardSoftLimitThreshold(LiftConstants::extendForwardLimit);
+    motor_rotateMain.ConfigReverseSoftLimitThreshold(LiftConstants::extendReverseLimit);
+
+    motor_rotateMain.ConfigForwardSoftLimitEnable(true);
+    motor_rotateMain.ConfigReverseSoftLimitEnable(true);
+
+    motor_rotateMain.SetSelectedSensorPosition(0);
+    motor_rotateMain.SetInverted(true);
+    motor_rotateFollow.Follow(motor_rotateMain);   
+
+    motor_rotateMain.SetNeutralMode(ctre::phoenix::motorcontrol::Brake);
+    motor_rotateFollow.SetNeutralMode(ctre::phoenix::motorcontrol::Brake);
+
+    motor_rotateMain.ConfigSelectedFeedbackSensor(FeedbackDevice::IntegratedSensor, 0, 10);
+    motor_rotateMain.ConfigAllowableClosedloopError(0, 0);
+    motor_rotateMain.Config_IntegralZone(0, 0);
+    motor_rotateMain.Config_kF(0, LiftConstants::main_KF);
+    motor_rotateMain.Config_kD(0, LiftConstants::main_KD);
+    motor_rotateMain.Config_kI(0, LiftConstants::main_KI);
+    motor_rotateMain.Config_kP(0, LiftConstants::main_KP);
+    motor_rotateMain.ConfigMotionAcceleration(LiftConstants::MAIN_MOTION_ACCELERATION);
+    motor_rotateMain.ConfigMotionCruiseVelocity(LiftConstants::MAIN_MOTION_CRUISE_VELOCITY);
 
     table->PutBoolean("Reverse Feeder?", false);
     table->PutNumber("Intake Reverse Speed", FeederConstants::DEFAULT_INTAKE_SPEED_REVERSE);
@@ -131,14 +152,14 @@ void Feeder::assignOutputs()
     if (state.feederState == FeederState::FEEDER_DISABLE) {
         motor_intake.Set(0);
         motor_stage.Set(0);
-        fixme motor_rotateRight.Set(0);// set rotate down
+        motor_rotateMain.Set(0);// set rotate down fixme
     }
     else if (state.feederState == FeederState::FEEDER_SHOOT) {
         motor_intake.Set(state.intakeForwardSpeed);
         motor_stage.Set(state.feederForwardSpeedShoot);
     }
     else if (state.feederState == FeederState::FEEDER_RETRACT){
-        fixme // set rotation to be up;
+        motor_rotateMain.Set(0); // set rotation to be up fixme
     }
     else if (state.feederState == Feeder::FEEDER_REVERSE) {
         motor_intake.Set(state.intakeReverseSpeed);

--- a/Competition/src/main/cpp/subsystems/Shooter.cpp
+++ b/Competition/src/main/cpp/subsystems/Shooter.cpp
@@ -29,6 +29,7 @@ void Shooter::init()
 {
     limeTable = nt::NetworkTableInstance::GetDefault().GetTable("limelight");
     liftTable = nt::NetworkTableInstance::GetDefault().GetTable("Lift");
+    feederTable = nt::NetworkTableInstance::GetDefault().GetTable("Feeder");
     initTable("Shooter");
     
     table->PutBoolean("Zero Turret", false);
@@ -174,7 +175,7 @@ void Shooter::assessInputs()
             state.turretState = TurretState::TURRET_HOME_LEFT;
         }
         else {
-            state.turretState == TurretState::TURRET_HOME_RIGHT;
+            state.turretState = TurretState::TURRET_HOME_RIGHT;
         }
     }
     else if (operatorController->leftStickXActive()) {

--- a/Competition/src/main/cpp/subsystems/Shooter.cpp
+++ b/Competition/src/main/cpp/subsystems/Shooter.cpp
@@ -169,7 +169,15 @@ void Shooter::assessInputs()
     }
     
     //Turret
-    if (operatorController->leftStickXActive()) {
+    if (feederTable->GetNumber("Intake Encoder Value", 0) > ShooterConstants::turretRotateIntakeThreshold) {
+        if (turretEncoder.GetPosition() > ShooterConstants::homePositionMid) {
+            state.turretState = TurretState::TURRET_HOME_LEFT;
+        }
+        else {
+            state.turretState == TurretState::TURRET_HOME_RIGHT;
+        }
+    }
+    else if (operatorController->leftStickXActive()) {
         state.turretState = TurretState::TURRET_MANUAL; // Operator control
     }
     else if (operatorController->GetYButton() || driverController->GetBButton()) {
@@ -247,13 +255,16 @@ void Shooter::analyzeDashboard()
     state.hoodLow = table->GetNumber("Hood Bottom Position", ShooterConstants::hoodBottom);
     state.hoodHigh = table->GetNumber("Hood Top Position", ShooterConstants::hoodTop);
 
-
+    
+    
     if (liftTable->GetNumber("Lift Main Encoder Value", 0) > ShooterConstants::turretRotateLiftThreshold) {
         state.turretState = TurretState::TURRET_HOME_LEFT;
         limelightTrack(false);
         state.hoodState = HoodState::HOOD_DOWN;
         state.flywheelState = FlywheelState::FLYWHEEL_DISABLE;
     }
+
+    
 
     if (state.turretState == TurretState::TURRET_TRACK && state.lastTurretState != TurretState::TURRET_TRACK){
         limelightTrack(true);

--- a/Competition/src/main/cpp/subsystems/Shooter.cpp
+++ b/Competition/src/main/cpp/subsystems/Shooter.cpp
@@ -169,7 +169,7 @@ void Shooter::assessInputs()
     }
     
     //Turret
-    if (feederTable->GetNumber("Intake Encoder Value", 0) > ShooterConstants::turretRotateIntakeThreshold) {
+    if (feederTable->GetNumber("Intake Encoder Value", 0) < FeederConstants::rotateForwardLimit / 2) {
         if (turretEncoder.GetPosition() > ShooterConstants::homePositionMid) {
             state.turretState = TurretState::TURRET_HOME_LEFT;
         }

--- a/Competition/src/main/cpp/subsystems/ValorSwerve.cpp
+++ b/Competition/src/main/cpp/subsystems/ValorSwerve.cpp
@@ -116,7 +116,7 @@ void ValorSwerve::loadAndSetAzimuthZeroReference()
     //azimuthSetpoint = fmod(azimuthSetpoint, SwerveConstants::AZIMUTH_COUNTS_PER_REV / SwerveConstants::AZIMUTH_GEAR_RATIO);
 
     // Set the azimuth offset to the calculated setpoint (which will take over in teleop)
-    azimuthFalcon->SetSelectedSensorPosition(azimuthSetpoint, 0, 10);
+    azimuthFalcon->SetSelectedSensorPosition(0, 0, 10);
     //std::cout << "pulled pospition from file" << std::endl;
 }
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -227,7 +227,6 @@ namespace ShooterConstants{
     constexpr static double turretLimitRight = 0 - 7;
 
     constexpr static double turretRotateLiftThreshold = 20000; // lowered from 64500
-    constexpr static double turretRotateIntakeThreshold = 829.63;  //set to intake rotate up threshold
     
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;
@@ -270,7 +269,7 @@ namespace FeederConstants{
     constexpr static double main_KI = 0.0;
     constexpr static double main_KP = 0.1;
 
-    constexpr static double MAIN_MOTION_CRUISE_VELOCITY = 50;
+    constexpr static double MAIN_MOTION_CRUISE_VELOCITY = 4000;
     constexpr static double MAIN_MOTION_ACCELERATION = MAIN_MOTION_CRUISE_VELOCITY * 1;
 
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -97,7 +97,7 @@ namespace SwerveConstants {
     constexpr static double AUTO_MAX_ACCEL_MPSS = AUTO_MAX_SPEED_MPS * .6; // * 1
     constexpr static double DRIVE_SLOW_SPEED_MPS = 1;
 
-    constexpr static double ROTATION_MAX_SPEED_RPS = 2*M_PI;// DRIVE_MAX_SPEED_MPS / std::hypot(module_diff / 2, module_diff / 2);
+    constexpr static double ROTATION_MAX_SPEED_RPS = 4 *M_PI;// DRIVE_MAX_SPEED_MPS / std::hypot(module_diff / 2, module_diff / 2);
     constexpr static double AUTO_MAX_ROTATION_RPS = 4 * M_PI;
     constexpr static double AUTO_MAX_ROTATION_ACCEL_RPSS = AUTO_MAX_ROTATION_RPS * .5; // * 1
     constexpr static double ROTATION_SLOW_SPEED_RPS = 1*M_PI;
@@ -227,6 +227,8 @@ namespace ShooterConstants{
     constexpr static double turretLimitRight = 0 - 7;
 
     constexpr static double turretRotateLiftThreshold = 20000; // lowered from 64500
+    constexpr static double turretRotateIntakeThreshold = 0; fixme // set to intake rotate up threshold
+    
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;
 
@@ -251,6 +253,8 @@ namespace FeederConstants{
 
     constexpr static int CACHE_SIZE = 20;
     constexpr static double JAM_CURRENT = 22;
+
+    
 }
 
 namespace MathConstants{

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -227,7 +227,7 @@ namespace ShooterConstants{
     constexpr static double turretLimitRight = 0 - 7;
 
     constexpr static double turretRotateLiftThreshold = 20000; // lowered from 64500
-    constexpr static double turretRotateIntakeThreshold = 2;  // fixme set to intake rotate up threshold
+    constexpr static double turretRotateIntakeThreshold = 829.63;  //set to intake rotate up threshold
     
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;
@@ -257,23 +257,21 @@ namespace FeederConstants{
     constexpr static int CACHE_SIZE = 20;
     constexpr static double JAM_CURRENT = 22;
 
+    constexpr static double tickToDegree = ((4200.0 /144.0) * 2048.0 ) / 360.0; 
 
-    constexpr static double rotateForwardLimit = 10;
-    constexpr static double rotateReverseLimit = 1;
-
-    constexpr static double rotateGearRatio = 1 / 29.16667; //fixme
-
+    constexpr static double rotateForwardLimit = 10 * tickToDegree;
+    constexpr static double rotateReverseLimit = 0;
 
 
-    //change to intake numbers fixme
+
+
     constexpr static double main_KF = 0.05;
     constexpr static double main_KD = 0.0;
     constexpr static double main_KI = 0.0;
     constexpr static double main_KP = 0.1;
 
-    //change to intake numbers fixme
-    constexpr static double MAIN_MOTION_CRUISE_VELOCITY = 15000;
-    constexpr static double MAIN_MOTION_ACCELERATION = MAIN_MOTION_CRUISE_VELOCITY * 7;
+    constexpr static double MAIN_MOTION_CRUISE_VELOCITY = 50;
+    constexpr static double MAIN_MOTION_ACCELERATION = MAIN_MOTION_CRUISE_VELOCITY * 1;
 
 
     

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -227,7 +227,7 @@ namespace ShooterConstants{
     constexpr static double turretLimitRight = 0 - 7;
 
     constexpr static double turretRotateLiftThreshold = 20000; // lowered from 64500
-    constexpr static double turretRotateIntakeThreshold = 12000;  // fixme set to intake rotate up threshold
+    constexpr static double turretRotateIntakeThreshold = 2;  // fixme set to intake rotate up threshold
     
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;
@@ -256,6 +256,25 @@ namespace FeederConstants{
 
     constexpr static int CACHE_SIZE = 20;
     constexpr static double JAM_CURRENT = 22;
+
+
+    constexpr static double rotateForwardLimit = 10;
+    constexpr static double rotateReverseLimit = 1;
+
+    constexpr static double rotateGearRatio = 1 / 29.16667; //fixme
+
+
+
+    //change to intake numbers fixme
+    constexpr static double main_KF = 0.05;
+    constexpr static double main_KD = 0.0;
+    constexpr static double main_KI = 0.0;
+    constexpr static double main_KP = 0.1;
+
+    //change to intake numbers fixme
+    constexpr static double MAIN_MOTION_CRUISE_VELOCITY = 15000;
+    constexpr static double MAIN_MOTION_ACCELERATION = MAIN_MOTION_CRUISE_VELOCITY * 7;
+
 
     
 }

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -227,7 +227,7 @@ namespace ShooterConstants{
     constexpr static double turretLimitRight = 0 - 7;
 
     constexpr static double turretRotateLiftThreshold = 20000; // lowered from 64500
-    constexpr static double turretRotateIntakeThreshold = 0; fixme // set to intake rotate up threshold
+    constexpr static double turretRotateIntakeThreshold = 12000;  // fixme set to intake rotate up threshold
     
     constexpr static double hubX = 0;
     constexpr static double hubY = 0;
@@ -241,6 +241,9 @@ namespace ShooterConstants{
 namespace FeederConstants{
     constexpr static int MOTOR_INTAKE_CAN_ID = 9;    //PDH slot 15
     constexpr static int MOTOR_STAGE_CAN_ID = 10;
+
+    constexpr static int MOTOR_ROTATE_MAIN_CAN_ID = 20;
+    constexpr static int MOTOR_ROTATE_FOLLOW_CAN_ID = 21;
 
     constexpr static int BANNER_DIO_PORT = 5;
 

--- a/Competition/src/main/include/Constants.h
+++ b/Competition/src/main/include/Constants.h
@@ -258,19 +258,16 @@ namespace FeederConstants{
 
     constexpr static double tickToDegree = ((4200.0 /144.0) * 2048.0 ) / 360.0; 
 
-    constexpr static double rotateForwardLimit = 10 * tickToDegree;
+    constexpr static double rotateForwardLimit = 20 * tickToDegree;
     constexpr static double rotateReverseLimit = 0;
-
-
-
 
     constexpr static double main_KF = 0.05;
     constexpr static double main_KD = 0.0;
     constexpr static double main_KI = 0.0;
     constexpr static double main_KP = 0.1;
 
-    constexpr static double MAIN_MOTION_CRUISE_VELOCITY = 4000;
-    constexpr static double MAIN_MOTION_ACCELERATION = MAIN_MOTION_CRUISE_VELOCITY * 1;
+    constexpr static double MAIN_MOTION_CRUISE_VELOCITY = 15000;
+    constexpr static double MAIN_MOTION_ACCELERATION = MAIN_MOTION_CRUISE_VELOCITY * 5;
 
 
     

--- a/Competition/src/main/include/subsystems/Feeder.h
+++ b/Competition/src/main/include/subsystems/Feeder.h
@@ -66,8 +66,8 @@ private:
 
     WPI_TalonFX motor_intake;
     WPI_TalonFX motor_stage;
-    WPI_TalonFX motor_rotateRight;
-    WPI_TalonFX motor_rotateLeft; 
+    WPI_TalonFX motor_rotateMain;
+    WPI_TalonFX motor_rotateFollow;
     
     //fixme // create motor group if needed
 

--- a/Competition/src/main/include/subsystems/Feeder.h
+++ b/Competition/src/main/include/subsystems/Feeder.h
@@ -17,6 +17,9 @@
 #include "sensors/ValorCurrentSensor.h"
 #include "sensors/ValorDebounceSensor.h"
 
+#include <frc2/command/FunctionalCommand.h>
+
+
 #ifndef FEEDER_H
 #define FEEDER_H
 
@@ -55,10 +58,12 @@ public:
         double feederForwardSpeedShoot;
         double feederReverseSpeed;
 
+
         FeederState feederState;
     } state;
 
     void resetIntakeSensor();
+
 
 private:
     ValorGamepad *driverController;
@@ -69,7 +74,6 @@ private:
     WPI_TalonFX motor_rotateMain;
     WPI_TalonFX motor_rotateFollow;
     
-    //fixme // create motor group if needed
 
 
 

--- a/Competition/src/main/include/subsystems/Feeder.h
+++ b/Competition/src/main/include/subsystems/Feeder.h
@@ -39,7 +39,8 @@ public:
         FEEDER_REVERSE,
         FEEDER_SHOOT,
         FEEDER_CURRENT_INTAKE,
-        FEEDER_REGULAR_INTAKE
+        FEEDER_REGULAR_INTAKE,
+        FEEDER_RETRACT
     };
     
     struct x
@@ -65,6 +66,12 @@ private:
 
     WPI_TalonFX motor_intake;
     WPI_TalonFX motor_stage;
+    WPI_TalonFX motor_rotateRight;
+    WPI_TalonFX motor_rotateLeft; 
+    
+    //fixme // create motor group if needed
+
+
 
     ValorCurrentSensor currentSensor;
     ValorDebounceSensor debounceSensor;

--- a/Competition/src/main/include/subsystems/Shooter.h
+++ b/Competition/src/main/include/subsystems/Shooter.h
@@ -142,6 +142,8 @@ public:
 
      std::shared_ptr<nt::NetworkTable> limeTable;
      std::shared_ptr<nt::NetworkTable> liftTable;
+     std::shared_ptr<nt::NetworkTable> feederTable;
+
 
      Drivetrain *odom;
 


### PR DESCRIPTION
It uses the same motion magic controller for TalonFX as the lift subsystem to move the intake to a specified degree when the driver B button is held. The normal disabled state for the feeder is the same with the addition of setting the intake target degree to an extended position. The turret behavior for the feeder is similar to that of the lift, in that after reacting to a certain target value the turret moves to the closest left or right limit and returns to tracking after intake is extended past the target value.